### PR TITLE
✨ feat: add Firefox support and fix XSS in library result rendering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,35 @@ jobs:
           zip -r "../KOSEN-OPAC-Checker-${{ needs.check-version.outputs.version }}.zip" .
           cd ..
 
+      - name: Sign Firefox extension (XPI)
+        id: sign_firefox
+        env:
+          WEB_EXT_API_KEY: ${{ secrets.AMO_JWT_ISSUER }}
+          WEB_EXT_API_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+        run: |
+          # Mozilla Add-on API (AMO) の unlisted 署名を使って xpi を生成
+          # AMO_JWT_ISSUER / AMO_JWT_SECRET が未設定の場合はスキップする
+          if [ -z "$WEB_EXT_API_KEY" ] || [ -z "$WEB_EXT_API_SECRET" ]; then
+            echo "AMO_JWT_ISSUER / AMO_JWT_SECRET が未設定のため、XPI署名をスキップします"
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          npx web-ext sign \
+            --source-dir=build \
+            --artifacts-dir=./web-ext-artifacts \
+            --channel=unlisted \
+            --api-key="$WEB_EXT_API_KEY" \
+            --api-secret="$WEB_EXT_API_SECRET"
+
+          XPI_PATH=$(find ./web-ext-artifacts -name '*.xpi' | head -n 1)
+          if [ -z "$XPI_PATH" ]; then
+            echo "署名済みXPIが見つかりませんでした" >&2
+            exit 1
+          fi
+          cp "$XPI_PATH" "./KOSEN-OPAC-Checker-${{ needs.check-version.outputs.version }}.xpi"
+          echo "signed=true" >> "$GITHUB_OUTPUT"
+
       - name: Create Release
         uses: actions/create-release@v1
         id: create_release
@@ -100,11 +129,16 @@ jobs:
           body: |
             ## KOSEN-OPAC-Checker ${{ needs.check-version.outputs.version }}
 
-            ### インストール方法
+            ### インストール方法（Chrome / Chromium系）
             1. `KOSEN-OPAC-Checker-${{ needs.check-version.outputs.version }}.zip` をダウンロード
             2. ファイルを解凍
             3. Chrome の拡張機能管理画面で「デベロッパーモード」を有効にする
             4. 「パッケージ化されていない拡張機能を読み込む」から解凍したフォルダを選択
+
+            ### インストール方法（Firefox）
+            1. `KOSEN-OPAC-Checker-${{ needs.check-version.outputs.version }}.xpi` をダウンロード
+            2. Firefoxでダウンロードしたファイルを開く（またはFirefoxにドラッグ＆ドロップ）
+            3. 表示される確認ダイアログでインストールを許可
 
             ### 変更内容
             manifest.json のバージョンを ${{ needs.check-version.outputs.version }} に更新
@@ -131,7 +165,18 @@ jobs:
           asset_name: KOSEN-OPAC-Checker-${{ needs.check-version.outputs.version }}.crx
           asset_content_type: application/x-chrome-extension
 
+      - name: Upload XPI to Release
+        if: steps.sign_firefox.outputs.signed == 'true'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./KOSEN-OPAC-Checker-${{ needs.check-version.outputs.version }}.xpi
+          asset_name: KOSEN-OPAC-Checker-${{ needs.check-version.outputs.version }}.xpi
+          asset_content_type: application/x-xpinstall
+
       - name: Clean up
         run: |
           rm -f extension-key.pem
-          rm -rf build
+          rm -rf build web-ext-artifacts

--- a/content-rakuten.js
+++ b/content-rakuten.js
@@ -1,4 +1,16 @@
 // 楽天市場書籍ページ用コンテンツスクリプト
+
+// OPAC/楽天から取得した動的な文字列をinnerHTMLに差し込む前にエスケープする
+function escapeHTML(value) {
+  if (value === null || value === undefined) return "";
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 class RakutenLibraryFinder {
   constructor() {
     this.buttonContainer = null;
@@ -733,7 +745,9 @@ class RakutenLibraryFinder {
     }
 
     const resultHTML = `
-      <a href="${bookUrl}" target="_blank" class="library-finder-button library-finder-primary-style">
+      <a href="${escapeHTML(
+        bookUrl
+      )}" target="_blank" class="library-finder-button library-finder-primary-style">
         <span class="library-finder-button-inner">
           <span class="library-finder-button-text">図書館で借りる</span>
         </span>
@@ -776,7 +790,9 @@ class RakutenLibraryFinder {
     const errorHTML = `
       <div class="library-finder-button library-finder-disabled">
         <span class="library-finder-button-inner">
-          <span class="library-finder-button-text" style="color: #e74c3c;">${message}</span>
+          <span class="library-finder-button-text" style="color: #e74c3c;">${escapeHTML(
+            message
+          )}</span>
         </span>
       </div>
     `;
@@ -808,12 +824,12 @@ class RakutenLibraryFinder {
 
     return `
       <div class="library-finder-result-item">
-        <h4>${book.title}</h4>
-        <p><strong>著者:</strong> ${book.author || "不明"}</p>
-        <p><strong>出版:</strong> ${book.publisher || "不明"} (${
-      book.year || "不明"
-    })</p>
-        <a href="${bookUrl}" target="_blank">詳細を見る</a>
+        <h4>${escapeHTML(book.title)}</h4>
+        <p><strong>著者:</strong> ${escapeHTML(book.author || "不明")}</p>
+        <p><strong>出版:</strong> ${escapeHTML(
+          book.publisher || "不明"
+        )} (${escapeHTML(book.year || "不明")})</p>
+        <a href="${escapeHTML(bookUrl)}" target="_blank">詳細を見る</a>
       </div>
     `;
   }

--- a/content.js
+++ b/content.js
@@ -1,4 +1,16 @@
 // コンテンツスクリプト - Amazonページに図書館情報を埋め込み
+
+// OPAC/Amazonから取得した動的な文字列をinnerHTMLに差し込む前にエスケープする
+function escapeHTML(value) {
+  if (value === null || value === undefined) return "";
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 class LibraryFinder {
   constructor() {
     this.buttonContainer = null;
@@ -600,7 +612,9 @@ class LibraryFinder {
     }
 
     const resultHTML = `
-      <a href="${bookUrl}" target="_blank" class="library-finder-button library-finder-primary-style">
+      <a href="${escapeHTML(
+        bookUrl
+      )}" target="_blank" class="library-finder-button library-finder-primary-style">
         <span class="library-finder-button-inner">
           <span class="library-finder-button-text">図書館で借りる</span>
         </span>
@@ -643,7 +657,9 @@ class LibraryFinder {
     const errorHTML = `
       <div class="library-finder-button library-finder-disabled">
         <span class="library-finder-button-inner">
-          <span class="library-finder-button-text" style="color: #d13212;">${message}</span>
+          <span class="library-finder-button-text" style="color: #d13212;">${escapeHTML(
+            message
+          )}</span>
         </span>
       </div>
     `;
@@ -675,14 +691,14 @@ class LibraryFinder {
 
     return `
       <div class="library-finder-result-item">
-        <h4 style="margin-top:0;">${book.title}</h4>
-        <p style="font-size:12px; margin-bottom: 5px;"><strong>著者:</strong> ${
+        <h4 style="margin-top:0;">${escapeHTML(book.title)}</h4>
+        <p style="font-size:12px; margin-bottom: 5px;"><strong>著者:</strong> ${escapeHTML(
           book.author || "不明"
-        }</p>
-        <p style="font-size:12px; margin-bottom: 10px;"><strong>出版:</strong> ${
+        )}</p>
+        <p style="font-size:12px; margin-bottom: 10px;"><strong>出版:</strong> ${escapeHTML(
           book.publisher || "不明"
-        } (${book.year || "不明"})</p>
-        <a href="${bookUrl}" target="_blank">詳細を見る</a>
+        )} (${escapeHTML(book.year || "不明")})</p>
+        <a href="${escapeHTML(bookUrl)}" target="_blank">詳細を見る</a>
       </div>
     `;
   }

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,8 @@
     }
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": ["background.js"]
   },
   "action": {
     "default_popup": "popup.html",
@@ -36,5 +37,14 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png",
     "1024": "icons/icon1024.png"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "kosen-opac-checker@fukayatti0.github.io",
+      "strict_min_version": "109.0",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- manifest.jsonをFirefox（MV3, 109+）互換にする
  - `background.scripts`をフォールバックとして追加
  - `browser_specific_settings.gecko`（id / strict_min_version / data_collection_permissions）を追加
- `content.js` / `content-rakuten.js`: OPAC・Amazon・楽天から取得した文字列（書名・著者・出版社・出版年・生成URL・エラーメッセージ）を`innerHTML`に挿入する前にエスケープするよう修正（web-ext lintのUNSAFE_VAR_ASSIGNMENT指摘への対応）

## Test plan
- [x] `web-ext lint --self-hosted` でmanifestエラー0件を確認
- [x] `web-ext run` でFirefox（temporary add-on）に読み込み、Amazon書籍ページで動作確認
- [x] エスケープ関数の単体動作確認（`<img onerror=...>` / 属性区切りペイロードが無害化されることを確認）
- [ ] 実際のFirefoxプロファイルでの手動確認（レビュー時にお願いします）

Closes #22