### PR TITLE
🔧 fix: correct gecko.id domain to match actual GitHub account

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -40,7 +40,7 @@
   },
   "browser_specific_settings": {
     "gecko": {
-      "id": "kosen-opac-checker@fukayatti0.github.io",
+      "id": "kosen-opac-checker@fukayatti.github.io",
       "strict_min_version": "109.0",
       "data_collection_permissions": {
         "required": ["none"]


### PR DESCRIPTION
誤って `fukayatti0` になっていた gecko.id を実際のGitHubアカウント `fukayatti` に修正。バージョンは上げないのでこのマージではCIのReleaseは発火しない想定。