### PR TITLE
🔧 fix: correct holar param and add NDL ISBN fallback

### DIFF
--- a/background.js
+++ b/background.js
@@ -111,11 +111,39 @@ class LibrarySearchService {
     console.log("🎯 handleLibrarySearch開始 - リクエスト受信:", request);
 
     try {
-      const { isbn, bookInfo, collegeId = "12" } = request;
+      let { isbn, bookInfo, collegeId = "12" } = request;
       console.log("📚 抽出されたデータ:", { isbn, bookInfo, collegeId });
 
       let result = null;
       let searchAttempts = [];
+
+      // 戦略0: ページからISBNが取れなかった場合、NDLサーチで補完
+      if (!isbn && bookInfo.title) {
+        console.log("🔍 戦略0: NDLサーチでISBN補完を試行中...");
+        try {
+          const resolvedIsbn = await this.resolveISBNViaNDL(
+            bookInfo.title,
+            bookInfo.author
+          );
+          searchAttempts.push({
+            type: "NDL補完",
+            query: bookInfo.title,
+            success: !!resolvedIsbn,
+          });
+          if (resolvedIsbn) {
+            console.log("✅ NDLサーチでISBN取得:", resolvedIsbn);
+            isbn = resolvedIsbn;
+          }
+        } catch (error) {
+          console.warn("NDLサーチエラー:", error.message);
+          searchAttempts.push({
+            type: "NDL補完",
+            query: bookInfo.title,
+            success: false,
+            error: error.message,
+          });
+        }
+      }
 
       // フォールバック検索戦略
       if (isbn) {
@@ -229,6 +257,37 @@ class LibrarySearchService {
     }
   }
 
+  async resolveISBNViaNDL(title, author) {
+    console.log("📡 NDLサーチでISBN補完:", { title, author });
+
+    const params = new URLSearchParams({ title: title.trim(), cnt: "3" });
+    if (author) {
+      params.set("creator", author.trim());
+    }
+
+    const response = await fetch(
+      `https://ndlsearch.ndl.go.jp/api/opensearch?${params.toString()}`
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const xml = await response.text();
+    const match = xml.match(
+      /<dc:identifier xsi:type="dcndl:ISBN">([\d\-]+)<\/dc:identifier>/
+    );
+
+    if (!match) {
+      console.log("📡 NDLサーチでISBNが見つかりませんでした");
+      return null;
+    }
+
+    const isbn = match[1].replace(/-/g, "");
+    console.log("📡 NDLサーチISBN抽出成功:", isbn);
+    return isbn;
+  }
+
   async searchByISBN(isbn, collegeId = "12") {
     console.log("ISBN検索実行:", isbn, "高専ID:", collegeId);
 
@@ -272,7 +331,7 @@ class LibrarySearchService {
 
     const postData = new URLSearchParams({
       words: keyword.trim(),
-      holar: "12",
+      holar: collegeId,
       formkeyno: "",
       sortkey: "",
       sorttype: "",

--- a/background.js
+++ b/background.js
@@ -127,15 +127,26 @@ class LibrarySearchService {
             bookInfo.title,
             bookInfo.author
           );
+
+          // ページから出版年が分かっている場合、同じ出版年の版を優先して試す
+          // （教科書などは版によってISBNが異なり、NDLの1件目が別版のことがあるため）
+          const sortedCandidates = bookInfo.year
+            ? [...ndlCandidates].sort((a, b) => {
+                const aMatch = a.year === bookInfo.year ? 0 : 1;
+                const bMatch = b.year === bookInfo.year ? 0 : 1;
+                return aMatch - bMatch;
+              })
+            : ndlCandidates;
+
           searchAttempts.push({
             type: "NDL補完",
             query: bookInfo.title,
-            success: ndlCandidates.length > 0,
-            candidates: ndlCandidates,
+            success: sortedCandidates.length > 0,
+            candidates: sortedCandidates,
           });
-          for (const candidate of ndlCandidates) {
-            if (!isbnCandidates.includes(candidate)) {
-              isbnCandidates.push(candidate);
+          for (const candidate of sortedCandidates) {
+            if (!isbnCandidates.includes(candidate.isbn)) {
+              isbnCandidates.push(candidate.isbn);
             }
           }
         } catch (error) {
@@ -277,14 +288,28 @@ class LibrarySearchService {
     }
 
     const xml = await response.text();
-    const matches = [
-      ...xml.matchAll(
-        /<dc:identifier xsi:type="dcndl:ISBN">([\d\-]+)<\/dc:identifier>/g
-      ),
-    ];
+    // <item>単位でISBNと出版年を対応付ける（版によって出版年が異なるため）
+    const items = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)].map(
+      (m) => m[1]
+    );
 
-    // 同じ版がハイフンあり/なしの両表記で入っていることがあるため正規化して重複除去
-    const candidates = [...new Set(matches.map((m) => m[1].replace(/-/g, "")))];
+    const candidates = [];
+    const seenIsbn = new Set();
+    for (const item of items) {
+      const isbnMatch = item.match(
+        /<dc:identifier xsi:type="dcndl:ISBN">([\d\-]+)<\/dc:identifier>/
+      );
+      if (!isbnMatch) continue;
+
+      const isbn = isbnMatch[1].replace(/-/g, "");
+      if (seenIsbn.has(isbn)) continue;
+      seenIsbn.add(isbn);
+
+      const yearMatch = item.match(
+        /<dc:date xsi:type="dcterms:W3CDTF">(\d{4})<\/dc:date>/
+      );
+      candidates.push({ isbn, year: yearMatch ? yearMatch[1] : null });
+    }
 
     console.log("📡 NDLサーチISBN候補:", candidates);
     return candidates;

--- a/background.js
+++ b/background.js
@@ -183,7 +183,7 @@ class LibrarySearchService {
         console.log("🔍 戦略2: タイトル検索を試行中...");
         try {
           const fullTitleQuery = this.generateFullTitleQuery(bookInfo);
-          result = await this.searchByKeyword(fullTitleQuery, collegeId);
+          result = await this.searchByTitle(fullTitleQuery, collegeId);
           searchAttempts.push({
             type: "タイトル検索",
             query: fullTitleQuery,
@@ -296,6 +296,48 @@ class LibrarySearchService {
     const postData = new URLSearchParams({
       isbn_issn: isbn,
       search_mode: "advanced",
+      listcnt: "50",
+      startpos: "",
+      fromDsp: "catsre",
+      sortkey: "",
+      sorttype: "",
+    });
+
+    const response = await fetch(
+      `https://libopac-c.kosen-k.go.jp/webopac${collegeId}/ctlsrh.do`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+          Referer: `https://libopac-c.kosen-k.go.jp/webopac${collegeId}/cattab.do`,
+          Accept:
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          "Accept-Language": "ja,en-US;q=0.7,en;q=0.3",
+        },
+        body: postData,
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const html = await response.text();
+    return this.parseSearchResults(html);
+  }
+
+  async searchByTitle(title, collegeId = "12") {
+    console.log("タイトル限定検索実行:", title, "高専ID:", collegeId);
+
+    // words（全項目横断）ではなく書名フィールド（srhclm1=title）に絞ることで
+    // 著者名や注記にたまたま同じ語が含まれるノイズを減らす
+    const postData = new URLSearchParams({
+      srhclm1: "title",
+      valclm1: title.trim(),
+      search_mode: "advanced",
+      holar: collegeId,
       listcnt: "50",
       startpos: "",
       fromDsp: "catsre",

--- a/background.js
+++ b/background.js
@@ -111,28 +111,32 @@ class LibrarySearchService {
     console.log("🎯 handleLibrarySearch開始 - リクエスト受信:", request);
 
     try {
-      let { isbn, bookInfo, collegeId = "12" } = request;
+      const { isbn, bookInfo, collegeId = "12" } = request;
       console.log("📚 抽出されたデータ:", { isbn, bookInfo, collegeId });
 
       let result = null;
       let searchAttempts = [];
 
-      // 戦略0: ページからISBNが取れなかった場合、NDLサーチで補完
-      if (!isbn && bookInfo.title) {
-        console.log("🔍 戦略0: NDLサーチでISBN補完を試行中...");
+      // ページから取れたISBNに加え、取れなかった／外れた場合に備えて
+      // NDLサーチから複数版のISBN候補を補完する（教科書などは版違いが多いため）
+      let isbnCandidates = isbn ? [isbn] : [];
+      if (bookInfo.title) {
+        console.log("🔍 戦略0: NDLサーチでISBN候補を補完中...");
         try {
-          const resolvedIsbn = await this.resolveISBNViaNDL(
+          const ndlCandidates = await this.resolveISBNCandidatesViaNDL(
             bookInfo.title,
             bookInfo.author
           );
           searchAttempts.push({
             type: "NDL補完",
             query: bookInfo.title,
-            success: !!resolvedIsbn,
+            success: ndlCandidates.length > 0,
+            candidates: ndlCandidates,
           });
-          if (resolvedIsbn) {
-            console.log("✅ NDLサーチでISBN取得:", resolvedIsbn);
-            isbn = resolvedIsbn;
+          for (const candidate of ndlCandidates) {
+            if (!isbnCandidates.includes(candidate)) {
+              isbnCandidates.push(candidate);
+            }
           }
         } catch (error) {
           console.warn("NDLサーチエラー:", error.message);
@@ -145,15 +149,14 @@ class LibrarySearchService {
         }
       }
 
-      // フォールバック検索戦略
-      if (isbn) {
-        // 戦略1: ISBN検索
-        console.log("🔍 戦略1: ISBN検索を試行中...");
+      // 戦略1: ISBN検索（ページ由来 + NDL補完の候補を順に試す）
+      for (const candidateIsbn of isbnCandidates) {
+        console.log("🔍 戦略1: ISBN検索を試行中...", candidateIsbn);
         try {
-          result = await this.searchByISBN(isbn, collegeId);
+          result = await this.searchByISBN(candidateIsbn, collegeId);
           searchAttempts.push({
             type: "ISBN",
-            query: isbn,
+            query: candidateIsbn,
             success: result.found,
           });
 
@@ -168,7 +171,7 @@ class LibrarySearchService {
           console.warn("ISBN検索エラー:", error.message);
           searchAttempts.push({
             type: "ISBN",
-            query: isbn,
+            query: candidateIsbn,
             success: false,
             error: error.message,
           });
@@ -257,10 +260,10 @@ class LibrarySearchService {
     }
   }
 
-  async resolveISBNViaNDL(title, author) {
-    console.log("📡 NDLサーチでISBN補完:", { title, author });
+  async resolveISBNCandidatesViaNDL(title, author) {
+    console.log("📡 NDLサーチでISBN候補を補完:", { title, author });
 
-    const params = new URLSearchParams({ title: title.trim(), cnt: "3" });
+    const params = new URLSearchParams({ title: title.trim(), cnt: "5" });
     if (author) {
       params.set("creator", author.trim());
     }
@@ -274,18 +277,17 @@ class LibrarySearchService {
     }
 
     const xml = await response.text();
-    const match = xml.match(
-      /<dc:identifier xsi:type="dcndl:ISBN">([\d\-]+)<\/dc:identifier>/
-    );
+    const matches = [
+      ...xml.matchAll(
+        /<dc:identifier xsi:type="dcndl:ISBN">([\d\-]+)<\/dc:identifier>/g
+      ),
+    ];
 
-    if (!match) {
-      console.log("📡 NDLサーチでISBNが見つかりませんでした");
-      return null;
-    }
+    // 同じ版がハイフンあり/なしの両表記で入っていることがあるため正規化して重複除去
+    const candidates = [...new Set(matches.map((m) => m[1].replace(/-/g, "")))];
 
-    const isbn = match[1].replace(/-/g, "");
-    console.log("📡 NDLサーチISBN抽出成功:", isbn);
-    return isbn;
+    console.log("📡 NDLサーチISBN候補:", candidates);
+    return candidates;
   }
 
   async searchByISBN(isbn, collegeId = "12") {

--- a/content-rakuten.js
+++ b/content-rakuten.js
@@ -266,7 +266,7 @@ class RakutenLibraryFinder {
 
   extractBookInfo() {
     console.log("📖 楽天書籍情報抽出開始");
-    this.bookInfo = { title: null, author: null, isbn: null };
+    this.bookInfo = { title: null, author: null, isbn: null, year: null };
 
     // タイトル抽出（楽天の実際の構造に基づく）
     let titleText = "";
@@ -363,7 +363,31 @@ class RakutenLibraryFinder {
 
     // ISBN抽出
     this.extractISBN();
+    this.extractPublicationYear();
     console.log("📖 楽天最終的な書籍情報:", this.bookInfo);
+  }
+
+  extractPublicationYear() {
+    console.log("📖 楽天出版年抽出開始");
+    const pageText = document.body.textContent || "";
+
+    // 「発行年月：2012年06月」「発売日：2012/06/01」等の表記から西暦4桁を取得
+    const patterns = [
+      /発行年月[^:：0-9]*[:：][^0-9]*(\d{4})年/,
+      /発売日[^:：0-9]*[:：][^0-9]*(\d{4})[\/年]/,
+      /出版年月[^:：0-9]*[:：][^0-9]*(\d{4})[\/年]/,
+    ];
+
+    for (const pattern of patterns) {
+      const match = pageText.match(pattern);
+      if (match) {
+        this.bookInfo.year = match[1];
+        console.log("📖 楽天出版年抽出成功:", this.bookInfo.year);
+        return;
+      }
+    }
+
+    console.log("📖 楽天出版年が見つかりませんでした");
   }
 
   extractISBN() {

--- a/content.js
+++ b/content.js
@@ -248,7 +248,7 @@ class LibraryFinder {
 
   extractBookInfo() {
     console.log("📖 書籍情報抽出開始");
-    this.bookInfo = { title: null, author: null, isbn: null };
+    this.bookInfo = { title: null, author: null, isbn: null, year: null };
 
     const titleEl = document.querySelector("#productTitle, h1#title");
     if (titleEl) {
@@ -302,7 +302,26 @@ class LibraryFinder {
     }
 
     this.extractISBN();
+    this.extractPublicationYear();
     console.log("📖 最終的な書籍情報:", this.bookInfo);
+  }
+
+  extractPublicationYear() {
+    console.log("📖 出版年抽出開始");
+    const pageText = document.body.textContent || "";
+
+    // Product Detailsの「発売日 : 2022/4/22」のような表記から西暦4桁を取得
+    const match = pageText.match(
+      /発売日[^:：0-9]*[:：][^0-9]*(\d{4})\/\d{1,2}\/\d{1,2}/
+    );
+
+    if (match) {
+      this.bookInfo.year = match[1];
+      console.log("📖 出版年抽出成功:", this.bookInfo.year);
+      return;
+    }
+
+    console.log("📖 出版年が見つかりませんでした");
   }
 
   extractISBN() {

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
     "*://amazon.co.jp/*",
     "*://books.rakuten.co.jp/*",
     "*://libopac-c.kosen-k.go.jp/*",
-    "*://m.media-amazon.com/*"
+    "*://m.media-amazon.com/*",
+    "*://ndlsearch.ndl.go.jp/*"
   ],
   "content_scripts": [
     {


### PR DESCRIPTION
## Summary
- `searchByKeyword`の`holar`が`"12"`固定になっていたバグを修正（選択中の`collegeId`を使うように）
- AmazonページでISBN抽出に失敗した場合、NDLサーチのOpenSearch APIでタイトル/著者からISBNを逆引きするフォールバックを追加（戦略0）
- `ndlsearch.ndl.go.jp`へのhost_permissionを追加

## Test plan
- [x] `node --check background.js`
- [x] `web-ext lint --self-hosted` でエラー0件
- [x] NDLサーチのレスポンスに対する正規表現抽出を実データで確認（リーダブルコード → `9784873115658`)
- [ ] 実際の拡張機能でAmazon/楽天ページからのend-to-end確認（レビュー時にお願いします）

Closes #29