### PR TITLE
✨ feat: show loan status (available / on loan with due date)

### DIFF
--- a/background.js
+++ b/background.js
@@ -132,6 +132,7 @@ class LibrarySearchService {
           if (result.found && result.books.length > 0) {
             console.log("✅ ISBN検索成功");
             result.searchMethod = "ISBN検索";
+            await this.enrichWithHoldings(result.books, collegeId);
             console.log("📤 検索成功レスポンスを送信:", result);
             sendResponse(result);
             return;
@@ -162,6 +163,7 @@ class LibrarySearchService {
           if (result.found && result.books.length > 0) {
             console.log("✅ タイトル検索成功");
             result.searchMethod = "タイトル検索";
+            await this.enrichWithHoldings(result.books, collegeId);
             console.log("📤 タイトル検索成功レスポンスを送信:", result);
             sendResponse(result);
             return;
@@ -190,6 +192,7 @@ class LibrarySearchService {
           if (result.found && result.books.length > 0) {
             console.log("✅ 名前検索成功");
             result.searchMethod = "名前検索";
+            await this.enrichWithHoldings(result.books, collegeId);
             console.log("📤 名前検索成功レスポンスを送信:", result);
             sendResponse(result);
             return;
@@ -227,6 +230,90 @@ class LibrarySearchService {
       console.log("📤 エラーレスポンスを送信:", errorResponse);
       sendResponse(errorResponse);
     }
+  }
+
+  async enrichWithHoldings(books, collegeId) {
+    // 詳細ページへのリクエストが増えるため、上位数件のみ貸出状況を取得する
+    const MAX_HOLDINGS_LOOKUPS = 5;
+    const targets = books.filter((book) => book.bibId).slice(0, MAX_HOLDINGS_LOOKUPS);
+
+    await Promise.all(
+      targets.map(async (book) => {
+        try {
+          const holdings = await this.fetchHoldings(book.bibId, collegeId);
+          book.holdings = holdings.copies;
+        } catch (error) {
+          console.warn("📋 貸出状況取得エラー:", book.bibId, error.message);
+          book.holdings = null;
+        }
+      })
+    );
+  }
+
+  async fetchHoldings(bibId, collegeId = "12") {
+    console.log("📋 貸出状況取得:", bibId, "高専ID:", collegeId);
+
+    // 直前の検索と同じセッション（Cookie）で叩く必要がある。
+    // セッションが無い状態でcatdbl.doを直接叩くと、所蔵情報が空のテンプレートしか返らない。
+    const response = await fetch(
+      `https://libopac-c.kosen-k.go.jp/webopac${collegeId}/catdbl.do?bibid=${encodeURIComponent(
+        bibId
+      )}`,
+      {
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+          Referer: `https://libopac-c.kosen-k.go.jp/webopac${collegeId}/cattab.do`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const html = await response.text();
+    return this.parseHoldings(html);
+  }
+
+  parseHoldings(html) {
+    // 所蔵情報テーブルは横型(syozou_yoko)・縦型(syozou_tate)の2つが
+    // 同じ内容で並んでいることがあるため、最初の1つだけを対象にする
+    const tableMatch = html.match(
+      /<div class="opac_booksyozou_area[^"]*">\s*<table>([\s\S]*?)<\/table>/
+    );
+    if (!tableMatch) {
+      return { copies: [] };
+    }
+
+    const rows = [...tableMatch[1].matchAll(/<tr>([\s\S]*?)<\/tr>/g)]
+      .map((m) => m[1])
+      .filter((row) => !row.includes("<th"));
+
+    // 列の並びは No./巻号/所蔵館/配置場所/請求記号/資料ID/状態/コメント/返却予定日/予約
+    const copies = rows.map((row) => {
+      const cells = [...row.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/g)].map((m) =>
+        m[1]
+          .replace(/<[^>]+>/g, " ")
+          .replace(/\s+/g, " ")
+          .trim()
+      );
+
+      const [, , library, location, callNumber, itemId, status, , dueDate] =
+        cells;
+
+      return {
+        library: library || "",
+        location: location || "",
+        callNumber: callNumber || "",
+        itemId: itemId || "",
+        onLoan: status === "貸出中",
+        dueDate: dueDate || "",
+      };
+    });
+
+    console.log("📋 貸出状況パース結果:", copies);
+    return { copies };
   }
 
   async searchByISBN(isbn, collegeId = "12") {

--- a/content-rakuten.js
+++ b/content-rakuten.js
@@ -753,7 +753,11 @@ class RakutenLibraryFinder {
     // bibIdまたはidプロパティをチェック
     const bookId = books[0].bibId || books[0].id;
     if (bookId && bookId.startsWith("BB")) {
-      bookUrl = `https://libopac-c.kosen-k.go.jp/webopac${this.collegeId}/${bookId}`;
+      // 「webopacXX/BBxxxxx」という一見きれいなURLは実在せず404になるため、
+      // 実際に書誌詳細を表示するcatdbl.doエンドポイントを使う
+      bookUrl = `https://libopac-c.kosen-k.go.jp/webopac${
+        this.collegeId
+      }/catdbl.do?bibid=${encodeURIComponent(bookId)}`;
       console.log("📚 BBIDを使用したURL生成:", bookUrl);
       console.log("📚 使用したID:", bookId);
       console.log("📚 使用した高専ID:", this.collegeId);
@@ -887,7 +891,11 @@ class RakutenLibraryFinder {
     console.log("📚 使用する高専ID:", this.collegeId);
 
     if (bookId && bookId.startsWith("BB")) {
-      bookUrl = `https://libopac-c.kosen-k.go.jp/webopac${this.collegeId}/${bookId}`;
+      // 「webopacXX/BBxxxxx」という一見きれいなURLは実在せず404になるため、
+      // 実際に書誌詳細を表示するcatdbl.doエンドポイントを使う
+      bookUrl = `https://libopac-c.kosen-k.go.jp/webopac${
+        this.collegeId
+      }/catdbl.do?bibid=${encodeURIComponent(bookId)}`;
       console.log("📚 詳細リンク用BBID URL生成:", bookUrl);
     } else if (book.url && book.url !== "undefined") {
       bookUrl = book.url;

--- a/content-rakuten.js
+++ b/content-rakuten.js
@@ -151,7 +151,28 @@ class RakutenLibraryFinder {
       .library-finder-primary-style:active * {
         color: #ffffff !important;
       }
-      
+
+      /* 貸出中ボタン風（オレンジ寄りの警告色） */
+      .library-finder-warning-style {
+        background: #e67e22;
+        color: #ffffff !important;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        border: 1px solid #ca6f1e;
+      }
+
+      .library-finder-warning-style * {
+        color: #ffffff !important;
+      }
+
+      .library-finder-warning-style:hover {
+        background: #f39c12;
+        box-shadow: 0 3px 6px rgba(0, 0, 0, 0.15);
+      }
+
+      .library-finder-warning-style:active {
+        background: #ca6f1e;
+      }
+
       /* 無効/検索中スタイル */
       .library-finder-disabled {
         background: #f0f0f0;
@@ -744,12 +765,24 @@ class RakutenLibraryFinder {
       console.log("📚 フォールバックURLを使用:", bookUrl);
     }
 
+    const holdingsSummary = this.getHoldingsSummary(books[0].holdings);
+    let buttonStyle = "library-finder-primary-style";
+    let buttonText = "図書館で借りる";
+    if (holdingsSummary && !holdingsSummary.available) {
+      buttonStyle = "library-finder-warning-style";
+      buttonText = holdingsSummary.nextDueDate
+        ? `貸出中（返却予定 ${holdingsSummary.nextDueDate}）`
+        : "貸出中";
+    }
+
     const resultHTML = `
       <a href="${escapeHTML(
         bookUrl
-      )}" target="_blank" class="library-finder-button library-finder-primary-style">
+      )}" target="_blank" class="library-finder-button ${buttonStyle}">
         <span class="library-finder-button-inner">
-          <span class="library-finder-button-text">図書館で借りる</span>
+          <span class="library-finder-button-text">${escapeHTML(
+            buttonText
+          )}</span>
         </span>
       </a>
     `;
@@ -802,6 +835,48 @@ class RakutenLibraryFinder {
     this.detailsContainer.style.display = "none";
   }
 
+  getHoldingsSummary(holdings) {
+    if (!holdings || holdings.length === 0) {
+      return null;
+    }
+
+    const available = holdings.filter((copy) => !copy.onLoan);
+    if (available.length > 0) {
+      return { available: true };
+    }
+
+    const dueDates = holdings.map((copy) => copy.dueDate).filter(Boolean).sort();
+    return { available: false, nextDueDate: dueDates[0] || null };
+  }
+
+  getHoldingsHTML(holdings) {
+    if (!holdings || holdings.length === 0) {
+      return "";
+    }
+
+    const items = holdings
+      .map((copy) => {
+        const statusText = copy.onLoan
+          ? `貸出中${copy.dueDate ? `（返却予定 ${copy.dueDate}）` : ""}`
+          : "貸出可";
+        const statusColor = copy.onLoan ? "#e67e22" : "#27ae60";
+        const detailParts = [copy.location, copy.callNumber]
+          .filter(Boolean)
+          .map((part) => escapeHTML(part));
+
+        return `
+          <li style="margin-bottom:4px;">
+            <span style="color:${statusColor}; font-weight:bold;">${escapeHTML(
+          statusText
+        )}</span>${detailParts.length ? " / " + detailParts.join(" / ") : ""}
+          </li>
+        `;
+      })
+      .join("");
+
+    return `<ul style="font-size:12px; margin: 8px 0 0 0; padding-left: 18px;">${items}</ul>`;
+  }
+
   getResultHTML(book) {
     console.log("📚 詳細表示用書籍データ:", book);
 
@@ -829,6 +904,7 @@ class RakutenLibraryFinder {
         <p><strong>出版:</strong> ${escapeHTML(
           book.publisher || "不明"
         )} (${escapeHTML(book.year || "不明")})</p>
+        ${this.getHoldingsHTML(book.holdings)}
         <a href="${escapeHTML(bookUrl)}" target="_blank">詳細を見る</a>
       </div>
     `;

--- a/content.js
+++ b/content.js
@@ -175,7 +175,25 @@ class LibraryFinder {
       background: #2980b9;
       box-shadow: 0 1px 3px rgba(0,0,0,.2) inset;
       }
-      
+
+      /* 貸出中ボタン風（オレンジ寄りの警告色） */
+      .library-finder-warning-style {
+      border-color: #e67e22;
+      background: #f5b041;
+      color: #000000;
+      box-shadow: 0 2px 5px 0 rgba(213,217,217,.5);
+      }
+
+      .library-finder-warning-style:hover {
+      background: #e67e22;
+      border-color: #ca6f1e;
+      }
+
+      .library-finder-warning-style:active {
+      background: #ca6f1e;
+      box-shadow: 0 1px 3px rgba(0,0,0,.2) inset;
+      }
+
       /* 無効/検索中スタイル */
       .library-finder-disabled {
       border-color: #D5D9D9;
@@ -611,12 +629,24 @@ class LibraryFinder {
       console.log("📚 フォールバックURLを使用:", bookUrl);
     }
 
+    const holdingsSummary = this.getHoldingsSummary(books[0].holdings);
+    let buttonStyle = "library-finder-primary-style";
+    let buttonText = "図書館で借りる";
+    if (holdingsSummary && !holdingsSummary.available) {
+      buttonStyle = "library-finder-warning-style";
+      buttonText = holdingsSummary.nextDueDate
+        ? `貸出中（返却予定 ${holdingsSummary.nextDueDate}）`
+        : "貸出中";
+    }
+
     const resultHTML = `
       <a href="${escapeHTML(
         bookUrl
-      )}" target="_blank" class="library-finder-button library-finder-primary-style">
+      )}" target="_blank" class="library-finder-button ${buttonStyle}">
         <span class="library-finder-button-inner">
-          <span class="library-finder-button-text">図書館で借りる</span>
+          <span class="library-finder-button-text">${escapeHTML(
+            buttonText
+          )}</span>
         </span>
       </a>
     `;
@@ -669,6 +699,48 @@ class LibraryFinder {
     this.detailsContainer.style.display = "none";
   }
 
+  getHoldingsSummary(holdings) {
+    if (!holdings || holdings.length === 0) {
+      return null;
+    }
+
+    const available = holdings.filter((copy) => !copy.onLoan);
+    if (available.length > 0) {
+      return { available: true };
+    }
+
+    const dueDates = holdings.map((copy) => copy.dueDate).filter(Boolean).sort();
+    return { available: false, nextDueDate: dueDates[0] || null };
+  }
+
+  getHoldingsHTML(holdings) {
+    if (!holdings || holdings.length === 0) {
+      return "";
+    }
+
+    const items = holdings
+      .map((copy) => {
+        const statusText = copy.onLoan
+          ? `貸出中${copy.dueDate ? `（返却予定 ${copy.dueDate}）` : ""}`
+          : "貸出可";
+        const statusColor = copy.onLoan ? "#e67e22" : "#27ae60";
+        const detailParts = [copy.location, copy.callNumber]
+          .filter(Boolean)
+          .map((part) => escapeHTML(part));
+
+        return `
+          <li style="margin-bottom:4px;">
+            <span style="color:${statusColor}; font-weight:bold;">${escapeHTML(
+          statusText
+        )}</span>${detailParts.length ? " / " + detailParts.join(" / ") : ""}
+          </li>
+        `;
+      })
+      .join("");
+
+    return `<ul style="font-size:12px; margin: 8px 0 0 0; padding-left: 18px;">${items}</ul>`;
+  }
+
   getResultHTML(book) {
     console.log("📚 詳細表示用書籍データ:", book);
 
@@ -698,6 +770,7 @@ class LibraryFinder {
         <p style="font-size:12px; margin-bottom: 10px;"><strong>出版:</strong> ${escapeHTML(
           book.publisher || "不明"
         )} (${escapeHTML(book.year || "不明")})</p>
+        ${this.getHoldingsHTML(book.holdings)}
         <a href="${escapeHTML(bookUrl)}" target="_blank">詳細を見る</a>
       </div>
     `;

--- a/content.js
+++ b/content.js
@@ -617,7 +617,11 @@ class LibraryFinder {
     // bibIdまたはidプロパティをチェック
     const bookId = books[0].bibId || books[0].id;
     if (bookId && bookId.startsWith("BB")) {
-      bookUrl = `https://libopac-c.kosen-k.go.jp/webopac${this.collegeId}/${bookId}`;
+      // 「webopacXX/BBxxxxx」という一見きれいなURLは実在せず404になるため、
+      // 実際に書誌詳細を表示するcatdbl.doエンドポイントを使う
+      bookUrl = `https://libopac-c.kosen-k.go.jp/webopac${
+        this.collegeId
+      }/catdbl.do?bibid=${encodeURIComponent(bookId)}`;
       console.log("📚 BBIDを使用したURL生成:", bookUrl);
       console.log("📚 使用したID:", bookId);
       console.log("📚 使用した高専ID:", this.collegeId);
@@ -751,7 +755,11 @@ class LibraryFinder {
     console.log("📚 使用する高専ID:", this.collegeId);
 
     if (bookId && bookId.startsWith("BB")) {
-      bookUrl = `https://libopac-c.kosen-k.go.jp/webopac${this.collegeId}/${bookId}`;
+      // 「webopacXX/BBxxxxx」という一見きれいなURLは実在せず404になるため、
+      // 実際に書誌詳細を表示するcatdbl.doエンドポイントを使う
+      bookUrl = `https://libopac-c.kosen-k.go.jp/webopac${
+        this.collegeId
+      }/catdbl.do?bibid=${encodeURIComponent(bookId)}`;
       console.log("📚 詳細リンク用BBID URL生成:", bookUrl);
     } else if (book.url && book.url !== "undefined") {
       bookUrl = book.url;


### PR DESCRIPTION
## Summary
- 検索結果の書誌(bibId)ごとに所蔵詳細ページ(`catdbl.do?bibid=...`)を取得し、コピー単位の貸出状況（貸出可／貸出中＋返却予定日）・請求記号・配置場所を取得
- メインボタンを状況に応じて色分け（貸出可=青「図書館で借りる」、全コピー貸出中=オレンジ「貸出中（返却予定 YYYY/M/D）」）
- 詳細カードにも各コピーの状態を一覧表示
- リクエスト数抑制のため上位5件のみ貸出状況を取得

## 実装上の注意点
- `catdbl.do?bibid=...`は検索直後と同じセッション(Cookie)で叩く必要がある。セッションが確立していない状態で単独で叩くと、実データの入っていない空のテンプレートHTMLが返ってくる（実際にcurlで確認済み）。fetch()は同一originへのCookieを自動送信するため、検索→貸出状況取得を同じhandleLibrarySearch内で連続して行う今回の実装なら問題ない

## Test plan
- [x] `node --check` 全ファイル
- [x] `web-ext lint --self-hosted` エラー0件
- [x] 実データでend-to-end確認（リーダブルコード、茨城高専=webopac12、2コピーとも貸出中・返却予定日2026/9/17を正しく取得）
- [x] Firefox（temporary add-on）で読み込み確認

Closes #31